### PR TITLE
Explicit autoforms

### DIFF
--- a/app/imports/components/apply/artists.jsx
+++ b/app/imports/components/apply/artists.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ListField, ListItemField, NestField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { ArtistsSchema } from '/imports/schemas/artists.js';
@@ -13,7 +13,7 @@ export class Artists extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.artists.title</T></h2>
         <AutoForm
           autosave
@@ -21,7 +21,18 @@ export class Artists extends ApplySection {
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
           model={this.props.model}
-        />
+        >
+          <ListField name="artists">
+            <ListItemField name="$">
+              <NestField>
+                <AutoField name="name" />
+                <AutoField name="cv" />
+                <AutoField name="work" />
+              </NestField>
+            </ListItemField>
+          </ListField>
+          <ErrorsField className="errors" />
+        </AutoForm>
       </section>
     );
   }

--- a/app/imports/components/apply/booth.jsx
+++ b/app/imports/components/apply/booth.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { BoothSchema } from '/imports/schemas/booth.js';
@@ -13,7 +13,7 @@ export class Booth extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.booth.title</T></h2>
         <T>apply.sections.booth.description</T>
         <AutoForm
@@ -22,7 +22,10 @@ export class Booth extends ApplySection {
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
           model={this.props.model}
-        />
+        >
+          <AutoField name="boothSize" />
+          <ErrorsField className="errors" />
+        </AutoForm>
       </section>
     );
   }

--- a/app/imports/components/apply/contactInformation.jsx
+++ b/app/imports/components/apply/contactInformation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { ContactInformationSchema } from '/imports/schemas/contactInformation.js';
@@ -13,7 +13,7 @@ export class ContactInformation extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.contactInformation.title</T></h2>
         <T>apply.sections.contactInformation.description</T>
         <AutoForm
@@ -22,7 +22,16 @@ export class ContactInformation extends ApplySection {
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
           model={this.props.model}
-        />
+        >
+          <AutoField name="contactName" />
+          <AutoField name="contactEmail" />
+          <AutoField name="contactPhone" />
+          <AutoField name="twitter" />
+          <AutoField name="facebook" />
+          <AutoField name="tumblr" />
+          <AutoField name="instagram" />
+          <ErrorsField className={'errors'} />
+        </AutoForm>
       </section>
     );
   }

--- a/app/imports/components/apply/contactInformation.jsx
+++ b/app/imports/components/apply/contactInformation.jsx
@@ -30,7 +30,7 @@ export class ContactInformation extends ApplySection {
           <AutoField name="facebook" />
           <AutoField name="tumblr" />
           <AutoField name="instagram" />
-          <ErrorsField className={'errors'} />
+          <ErrorsField className="errors" />
         </AutoForm>
       </section>
     );

--- a/app/imports/components/apply/galleryInformation.jsx
+++ b/app/imports/components/apply/galleryInformation.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import i18n from 'meteor/universe:i18n';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { GalleryInformationSchema } from '/imports/schemas/galleryInformation.js';
@@ -14,14 +14,27 @@ export class GalleryInformation extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.galleryInformation.title</T></h2>
         <AutoForm
           autosave
           schema={GalleryInformationSchema}
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
-          model={this.props.model}/>
+          model={this.props.model}
+        >
+          <AutoField name="galleryName" />
+          <AutoField name="address1" />
+          <AutoField name="address2" />
+          <AutoField name="city" />
+          <AutoField name="state" />
+          <AutoField name="postalCode" />
+          <AutoField name="country" />
+          <AutoField name="galleryPhone" />
+          <AutoField name="galleryEmail" />
+          <AutoField name="website" />
+          <ErrorsField className={'errors'} />
+        </AutoForm>
       </section>
     );
   }

--- a/app/imports/components/apply/galleryInformation.jsx
+++ b/app/imports/components/apply/galleryInformation.jsx
@@ -33,7 +33,7 @@ export class GalleryInformation extends ApplySection {
           <AutoField name="galleryPhone" />
           <AutoField name="galleryEmail" />
           <AutoField name="website" />
-          <ErrorsField className={'errors'} />
+          <ErrorsField className="errors" />
         </AutoForm>
       </section>
     );

--- a/app/imports/components/apply/proposal.jsx
+++ b/app/imports/components/apply/proposal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { ProposalSchema } from '/imports/schemas/proposal.js';
@@ -13,7 +13,7 @@ export class Proposal extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.proposal.title</T></h2>
         <T>apply.sections.proposal.description</T>
         <AutoForm
@@ -21,7 +21,15 @@ export class Proposal extends ApplySection {
           schema={ProposalSchema}
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
-          model={this.props.model}/>
+          model={this.props.model}
+        >
+          <AutoField name="galleryHistory" />
+          <AutoField name="artistsRepresented" />
+          <AutoField name="galleryYear" />
+          <AutoField name="participation" />
+          <AutoField name="standProposal" />
+          <ErrorsField className={'errors'} />
+        </AutoForm>
       </section>
     );
   }

--- a/app/imports/components/apply/proposal.jsx
+++ b/app/imports/components/apply/proposal.jsx
@@ -28,7 +28,7 @@ export class Proposal extends ApplySection {
           <AutoField name="galleryYear" />
           <AutoField name="participation" />
           <AutoField name="standProposal" />
-          <ErrorsField className={'errors'} />
+          <ErrorsField className="errors" />
         </AutoForm>
       </section>
     );

--- a/app/imports/components/apply/terms.jsx
+++ b/app/imports/components/apply/terms.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoForm } from 'uniforms-unstyled';
+import { AutoForm, AutoField, ErrorsField } from 'uniforms-unstyled';
 
 // Import schemas
 import { TermsSchema } from '/imports/schemas/terms.js';
@@ -12,7 +12,7 @@ export class Terms extends ApplySection {
     const T = i18n.createComponent();
 
     return (
-      <section>
+      <section className="apply-section">
         <h2><T>apply.sections.terms.title</T></h2>
         <T>apply.sections.terms.description</T>
         <AutoForm
@@ -20,7 +20,11 @@ export class Terms extends ApplySection {
           schema={TermsSchema}
           onSubmit={this.onSubmit.bind(this)}
           onValidate={this.onValidate.bind(this)}
-          model={this.props.model} />
+          model={this.props.model}
+        >
+          <AutoField name="signature" />
+          <ErrorsField className="errors" />
+        </AutoForm>
         <T>apply.sections.terms.agreement</T>
       </section>
     );

--- a/app/imports/schemas/applicationPayment.js
+++ b/app/imports/schemas/applicationPayment.js
@@ -52,6 +52,7 @@ const Schema = new SimpleSchema({
       options: function () {
         // This use " to keep literal values
         return [
+          {value: "", label: "",},
           {value: "Afghanistan", label: "Afghanistan",},
           {value: "Åland Islands", label: "Åland Islands",},
           {value: "Albania", label: "Albania",},

--- a/app/imports/schemas/applicationPayment.js
+++ b/app/imports/schemas/applicationPayment.js
@@ -1,9 +1,14 @@
 /* globals _ */
+import { TextField } from 'uniforms-unstyled';
+
 const schemaLocaleBase = 'apply.payment.';
 
 const Schema = new SimpleSchema({
   'card.number': {
     type: Number,
+    uniforms: {
+      component: TextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'cardNumber.label'),
   },
   'card.name': {
@@ -12,14 +17,23 @@ const Schema = new SimpleSchema({
   },
   'card.exp_year': {
     type: Number,
+    uniforms: {
+      component: TextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'expirationYear.label'),
   },
   'card.exp_month': {
     type: Number,
+    uniforms: {
+      component: TextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'expirationMonth.label'),
   },
   'card.cvc': {
     type: Number,
+    uniforms: {
+      component: TextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'cvc.label'),
   },
   'address.street1': {

--- a/app/imports/schemas/artists.js
+++ b/app/imports/schemas/artists.js
@@ -52,7 +52,7 @@ export const ArtistsSchema = new SimpleSchema({
     label: () => i18n.__(schemaLocaleBase + 'work.dimensions.label'),
   },
   'artists.$.work.$.year': {
-    type: Number,
+    type: String,
     label: () => i18n.__(schemaLocaleBase + 'work.year.label'),
   },
 });

--- a/app/imports/schemas/contactInformation.js
+++ b/app/imports/schemas/contactInformation.js
@@ -8,6 +8,7 @@ export const ContactInformationSchema = new SimpleSchema({
   },
   contactEmail: {
     type: String,
+    regEx: SimpleSchema.RegEx.Email,
     label: () => i18n.__(schemaLocaleBase + 'contactEmail.label'),
   },
   contactPhone: {

--- a/app/imports/schemas/galleryInformation.js
+++ b/app/imports/schemas/galleryInformation.js
@@ -297,10 +297,12 @@ export const GalleryInformationSchema = new SimpleSchema({
   },
   galleryEmail: {
     type: String,
+    regEx: SimpleSchema.RegEx.Email,
     label: () => i18n.__(schemaLocaleBase + 'galleryEmail.label'),
   },
   website: {
     type: String,
+    regEx: SimpleSchema.RegEx.Url,
     optional: true,
     label: () => i18n.__(schemaLocaleBase + 'website.label'),
   },

--- a/app/imports/schemas/galleryInformation.js
+++ b/app/imports/schemas/galleryInformation.js
@@ -302,7 +302,7 @@ export const GalleryInformationSchema = new SimpleSchema({
   },
   website: {
     type: String,
-    regEx: SimpleSchema.RegEx.Url,
+    regEx: SimpleSchema.RegEx.WeakDomain,
     optional: true,
     label: () => i18n.__(schemaLocaleBase + 'website.label'),
   },

--- a/app/imports/schemas/proposal.js
+++ b/app/imports/schemas/proposal.js
@@ -1,4 +1,4 @@
-import { LongTextField } from 'uniforms-unstyled';
+import { TextField, LongTextField } from 'uniforms-unstyled';
 
 const schemaLocaleBase = 'apply.sections.proposal.';
 
@@ -22,10 +22,14 @@ export const ProposalSchema = new SimpleSchema({
   },
   galleryYear: {
     type: Number,
+    uniforms: {
+      component: TextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'galleryYear.label'),
   },
   participation: {
     type: String,
+    max: 2000,
     uniforms: {
       component: LongTextField,
     },

--- a/app/imports/schemas/proposal.js
+++ b/app/imports/schemas/proposal.js
@@ -26,6 +26,9 @@ export const ProposalSchema = new SimpleSchema({
   },
   participation: {
     type: String,
+    uniforms: {
+      component: LongTextField,
+    },
     label: () => i18n.__(schemaLocaleBase + 'participation.label'),
   },
   standProposal: {


### PR DESCRIPTION
Makes `<AutoForms>` declaration more explicit by setting each field with `<AutoField>`.
Add some details to schemas, like specific input types, regex or max sizes.
Add classes to the form wrapper and the errors section.
