### PR TITLE
add cvc and card number as String

### DIFF
--- a/app/imports/schemas/applicationPayment.js
+++ b/app/imports/schemas/applicationPayment.js
@@ -5,7 +5,7 @@ const schemaLocaleBase = 'apply.payment.';
 
 const Schema = new SimpleSchema({
   'card.number': {
-    type: Number,
+    type: String,
     label: () => i18n.__(schemaLocaleBase + 'cardNumber.label'),
   },
   'card.name': {
@@ -24,7 +24,7 @@ const Schema = new SimpleSchema({
     min: 1,
   },
   'card.cvc': {
-    type: Number,
+    type: String,
     label: () => i18n.__(schemaLocaleBase + 'cvc.label'),
   },
   'address.street1': {


### PR DESCRIPTION
There is a problem with one applicant whos CVC number starts with a 0. The field was `type="number"` so it would remove leading zeros for obvious reasons. This fixes it.
